### PR TITLE
docs: add Mermaid dependency diagrams to phase documentation

### DIFF
--- a/docs/phases/phase-1.md
+++ b/docs/phases/phase-1.md
@@ -226,6 +226,23 @@ Create an example demonstrating how to integrate GOD MODE into a React applicati
 
 ---
 
+## Dependency Diagram
+
+```mermaid
+graph TD
+    T1[TASK 1: Type Definitions Extraction] --> T2[TASK 2: React Context Provider]
+    T1 --> T3[TASK 3: Public API & Entry Point]
+    T2 --> T3
+    T1 --> T4[TASK 4: Test Suite]
+    T2 --> T4
+    T3 --> T4
+    T4 --> T5[TASK 5: CI/CD Pipeline & Release]
+    T1 --> T6[TASK 6: Usage Example]
+    T2 --> T6
+```
+
+---
+
 ## Effort Estimation
 
 | TASK                           | Complexity | Priority | Dependencies           |

--- a/docs/phases/phase-2.md
+++ b/docs/phases/phase-2.md
@@ -197,6 +197,23 @@ Build a theming system that allows the GOD MODE window to blend into any applica
 
 ---
 
+## Dependency Diagram
+
+```mermaid
+graph TD
+    P1[Phase 1: Core Types & Provider] --> T1[TASK 1: Floating Window]
+    T1 --> T2[TASK 2: Tab System]
+    T1 --> T6[TASK 6: Theming & Styling]
+    T2 --> T3[TASK 3: Query Panel]
+    T2 --> T4[TASK 4: Context Panel]
+    T2 --> T5[TASK 5: Search Panel]
+    T6 --> T3
+    T6 --> T4
+    T6 --> T5
+```
+
+---
+
 ## Effort Estimation
 
 | TASK                 | Complexity | Priority | Dependencies   |

--- a/docs/phases/phase-3.md
+++ b/docs/phases/phase-3.md
@@ -174,6 +174,23 @@ Enable saving, loading, and managing conversation sessions across browser sessio
 
 ---
 
+## Dependency Diagram
+
+```mermaid
+graph TD
+    P1[Phase 1: Core Types] --> T2[TASK 2: Conversation Agent Core]
+    P2[Phase 2: UI Components] --> T1[TASK 1: Conversation Panel UI]
+    T2 --> T1
+    T2 --> T3[TASK 3: Context Awareness]
+    T1 --> T5[TASK 5: Conversation Persistence]
+    T2 --> T5
+    T2 --> T4[TASK 4: Guided Brainstorming]
+    T3 --> T4
+    T5 --> T4
+```
+
+---
+
 ## Effort Estimation
 
 | TASK                        | Complexity | Priority | Dependencies     |

--- a/docs/phases/phase-4.md
+++ b/docs/phases/phase-4.md
@@ -178,6 +178,21 @@ Build the end-to-end flow from draft to published GitHub issue, including confir
 
 ---
 
+## Dependency Diagram
+
+```mermaid
+graph TD
+    P1[Phase 1: Core Types] --> T2[TASK 2: GitHub Authentication]
+    P2[Phase 2: UI Components] --> T1[TASK 1: Issue Draft Panel]
+    P3[Phase 3: AI Conversation] --> T4[TASK 4: Issue Generation Engine]
+    T2 --> T3[TASK 3: GitHub API Client]
+    T1 --> T5[TASK 5: Issue Publishing Flow]
+    T3 --> T5
+    T4 --> T5
+```
+
+---
+
 ## Effort Estimation
 
 | TASK                       | Complexity | Priority | Dependencies           |

--- a/docs/phases/phase-5.md
+++ b/docs/phases/phase-5.md
@@ -178,6 +178,22 @@ Enable uploading screenshots when creating GitHub issues, embedding them as inli
 
 ---
 
+## Dependency Diagram
+
+```mermaid
+graph TD
+    P1[Phase 1: Core Types] --> T1[TASK 1: Screen Capture Engine]
+    P2[Phase 2: UI Components] --> T2[TASK 2: Annotation Canvas]
+    T1 --> T4[TASK 4: Screenshot Persistence]
+    T1 --> T3[TASK 3: Screenshot Integration]
+    T2 --> T3
+    P4[Phase 4: GitHub Integration] --> T3
+    T1 --> T5[TASK 5: Screenshot Upload]
+    P4 --> T5
+```
+
+---
+
 ## Effort Estimation
 
 | TASK                      | Complexity | Priority | Dependencies             |


### PR DESCRIPTION
## Summary

- Add Mermaid dependency diagrams to all 5 phase documents in `docs/phases/`
- Matches the documentation style used in the [isocubic](https://github.com/netkeep80/isocubic) repository (e.g., `docs/phases/phase-1.md` includes a dependency graph)
- This is a follow-up to PR #4 which was merged before this enhancement could be included

## Changes

- `docs/phases/phase-1.md` — add task dependency diagram (TASK 1 → TASK 6)
- `docs/phases/phase-2.md` — add task dependency diagram with Phase 1 dependency
- `docs/phases/phase-3.md` — add task dependency diagram with Phase 1 & 2 dependencies
- `docs/phases/phase-4.md` — add task dependency diagram with Phase 1–3 dependencies
- `docs/phases/phase-5.md` — add task dependency diagram with Phase 1, 2, 4 dependencies

## Test plan

- [x] All 81 existing tests pass
- [x] Prettier formatting verified
- [x] Documentation-only changes — no source code modified

Relates to #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)